### PR TITLE
add(set): if the expires is number, then convert to Date.

### DIFF
--- a/src/Cookie.ts
+++ b/src/Cookie.ts
@@ -77,6 +77,11 @@ class Cookie {
    */
   /* eslint-disable @typescript-eslint/no-explicit-any */
   public set(name: string, value: any, options?: CookieSetOptions): void {
+    // if the expires is number, then convert to Date.
+    if (options && typeof options.expires === 'number') {
+      options.expires = new Date((new Date() as any) * 1 + options.expires * 864e+5);
+    }
+
     if (this.isServer && this.ctx) {
       const cookies: string[] = this.ctx.res.getHeader(SET_COOKIE_HEADER) as string[] || []
 


### PR DESCRIPTION
if the expires is number, then convert to Date.
now expires types expand to Date and number.

if expires is 1, it means 1day (60 * 60 * 24 * 1000).

ex) expires after 1day.
cookie.set('name', 'keiches', { expires: 1 });

ex) expires after 1hour.
cookie.set('name', 'keiches', { expires: 1 / 24 });