### PR TITLE
Fix a getInitialProps error when using getServerSideProps

### DIFF
--- a/example/pages/server-side-props.jsx
+++ b/example/pages/server-side-props.jsx
@@ -1,0 +1,41 @@
+import Head from 'next/head'
+import { useCookie, withCookie } from 'next-cookie'
+import React from 'react'
+
+class ServerSidePropsPage extends React.Component {
+  render() {
+    const { cookieString } = this.props
+
+    let text = ""
+    if (Object.keys(cookieString).length > 0) {
+      text = JSON.stringify(cookieString)
+    }
+
+    return (
+      <div className="container">
+        <Head>
+          <link rel="stylesheet" href="/static/app.css" />
+        </Head>
+
+        <section className="section">
+          <p className="section__text">Cookie result:</p>
+          <textarea value={text} rows={10} readOnly onChange={() => {}}></textarea>
+        </section>
+      </div>
+    );
+  }
+}
+
+export function getServerSideProps(context) {
+  const cookie = useCookie(context)
+
+  cookie.set('getServerSideProps', 'This value is set by getServerSideProps.')
+
+  return {
+    props: {
+      cookieString: cookie.getAll()
+    }
+  }
+}
+
+export default withCookie(ServerSidePropsPage)

--- a/src/withCookie.tsx
+++ b/src/withCookie.tsx
@@ -33,20 +33,18 @@ export function withCookie<Props extends WithCookieProps, InitialProps extends {
     }
   }
 
-  WithCookieWrapper.getInitialProps = async (ctx: WithCookieContext): Promise<InitialProps> => {
-    let initialProps = {}
-
-    if (ComposedComponent.getInitialProps) {
+  if (ComposedComponent.getInitialProps) {
+    WithCookieWrapper.getInitialProps = async (ctx: WithCookieContext): Promise<InitialProps> => {
       ctx.cookie = new Cookie(ctx)
 
-      initialProps = await ComposedComponent.getInitialProps(ctx)
+      const initialProps = await ComposedComponent.getInitialProps(ctx)
 
       if (ctx.cookie) {
         delete ctx.cookie
       }
-    }
 
-    return initialProps as InitialProps
+      return initialProps as InitialProps
+    }
   }
 
   return WithCookieWrapper


### PR DESCRIPTION
Fixes a bug that prevents wrappers from declaring `getInitialProps` when using `getServerSideProps`.

=> https://github.com/tokuda109/next-cookie/pull/152/commits/2fdefef40cc588873d9c0ff6a12891ad07af2f10#diff-de7b648e7f9de28c8d8516574e9becdb

There is sample code to make sure it works.

=> https://github.com/tokuda109/next-cookie/pull/152/commits/2fdefef40cc588873d9c0ff6a12891ad07af2f10#diff-9d27bb7996267504b2866691da79ca6b