### PR TITLE
refactor(deps): move next to peerdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "kind-of": ">=6.0.3",
     "minimist": ">=1.2.5",
-    "next": ">9.5.0",
     "universal-cookie": "~4.0.4"
   },
   "devDependencies": {
@@ -64,5 +63,8 @@
     "ts-jest": "26.5.5",
     "tslib": "2.2.0",
     "typescript": "4.2.4"
+  },
+  "peerDependencies": {
+    "next": ">9.5.0"
   }
 }


### PR DESCRIPTION
next-cookie is depending on next>9.5.0.

When installing next-cookies within our project (running Next 10.2.1) we get both Next 10.2.0 and 10.2.1 because of the required dependency in next-cookie. I've moved Next to peerdependencies to prevent this from happening.